### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
Hi nbr23,

I use your nice project in my IRC bot (as a submodule) and I notice that my git client always reports the submodule as dirty, due to `__pycache__/` directories.

I submit you this pull request to fix this annoying problem.

Best regards,
